### PR TITLE
docs: translate all markdown files to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
-# Next.js Stripe ECサイト
+# Next.js Stripe EC Site
 
-![デモ](docs/demo.gif)
+![Demo](docs/demo.gif)
 
-**Clerk認証とStripe決済を統合したサブスクリプション対応のモダンなECサイト**
+**Modern EC site with subscription support integrating Clerk authentication and Stripe payments**
 
-SaaS向けの機能を含む本格的なECプラットフォームです。
+A full-featured EC platform with functionality for SaaS applications.
 
-## セットアップ手順
+## Setup Instructions
 
-### 1. Stripe Setup (決済と商品設定)
+### 1. Stripe Setup (Payments and Product Configuration)
 
-- [Stripeアカウントセットアップ](docs/stripe-01-setup.md)
-- [商品とPriceの作成](docs/stripe-02-product-and-price.md)
-- [Webhookの設定](docs/stripe-03-webhook.md)
+- [Stripe Account Setup](docs/stripe-01-setup.md)
+- [Create Products and Prices](docs/stripe-02-product-and-price.md)
+- [Webhook Configuration](docs/stripe-03-webhook.md)
 
-### 2. Clerk Setup (認証・ユーザー管理)
+### 2. Clerk Setup (Authentication and User Management)
 
-- [Clerk認証セットアップ](docs/clerk.md)
-- [Clerk Billing セットアップ](docs/clerk-billing-setup.md)
+- [Clerk Authentication Setup](docs/clerk.md)
+- [Clerk Billing Setup](docs/clerk-billing-setup.md)
 
-### 3. 依存関係のインストール
+### 3. Install Dependencies
 
 ```bash
 npm install
 ```
 
-### 4. 環境変数の設定
+### 4. Environment Variables Setup
 
-`.env.local`ファイルを作成し、以下の内容を追加:
+Create a `.env.local` file and add the following content:
 
 ```env
 # Stripe Configuration
@@ -43,152 +43,152 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_your_clerk_publishable_key_here
 CLERK_SECRET_KEY=sk_test_your_clerk_secret_key_here
 ```
 
-### 5. 商品データの更新
+### 5. Update Product Data
 
-`pages/api/products.ts`を編集し、Stripeで作成した商品データを設定してください。
+Edit `pages/api/products.ts` and configure the product data created in Stripe.
 
-## Local開発
+## Local Development
 
-### 開発サーバーの起動
+### Start Development Server
 
 ```bash
 npm run dev
 ```
 
-[http://localhost:3000](http://localhost:3000)でアプリケーションを確認できます。
+You can view the application at [http://localhost:3000](http://localhost:3000).
 
-**Note**: 開発サーバーはTurbopackを使用して高速化されています。
+**Note**: The development server is accelerated using Turbopack.
 
-### コード品質チェック
+### Code Quality Check
 
 ```bash
-npm run lint        # ESLintでコード品質チェック
-npx tsc --noEmit    # TypeScript型チェック
-npm run build       # 本番ビルド
+npm run lint        # Check code quality with ESLint
+npx tsc --noEmit    # TypeScript type check
+npm run build       # Production build
 ```
 
-## 主な機能
+## Main Features
 
-### ページ構成
+### Page Structure
 
-- **`/` (ホームページ)**
-  - 未認証時: スタイリッシュなランディングページ（新規登録・ログインボタン）
-  - 認証済み: 商品一覧ページ
+- **`/` (Homepage)**
+  - Unauthenticated: Stylish landing page (with sign-up/login buttons)
+  - Authenticated: Product listing page
 
 - **`/pricing`**
-  - サブスクリプションプランの表示
-  - Clerkの料金テーブルコンポーネントを使用
-  - 14日間の無料トライアル対応
+  - Subscription plan display
+  - Uses Clerk's pricing table component
+  - 14-day free trial support
 
 - **`/account`**
-  - ユーザープロフィール管理
-  - サブスクリプション・請求設定
-  - 認証が必要
+  - User profile management
+  - Subscription and billing settings
+  - Authentication required
 
 - **`/monitoring`**
-  - プレミアム機能: ビジネス分析ダッシュボード
-  - 機能ベースのアクセス制御
-  - アップグレードプロンプト表示
+  - Premium feature: Business analytics dashboard
+  - Feature-based access control
+  - Upgrade prompt display
 
 - **`/sign-in` / `/sign-up`**
-  - Clerkによる認証ページ（モーダル表示）
-  - Google OAuth対応
+  - Authentication pages by Clerk (modal display)
+  - Google OAuth support
 
 - **`/success`**
-  - 決済完了ページ
-  - Stripeからのリダイレクト先
+  - Payment completion page
+  - Redirect destination from Stripe
 
 - **`/subscription-success`**
-  - サブスクリプション完了ページ
+  - Subscription completion page
 
-### API エンドポイント
+### API Endpoints
 
-- **`/api/products`**: 商品データ取得
-- **`/api/checkout`**: チェックアウトセッション作成（認証必須）
-- **`/api/create-subscription`**: サブスクリプション作成（認証必須）
-- **`/api/webhooks`**: Stripe Webhook処理
+- **`/api/products`**: Fetch product data
+- **`/api/checkout`**: Create checkout session (authentication required)
+- **`/api/create-subscription`**: Create subscription (authentication required)
+- **`/api/webhooks`**: Stripe webhook processing
 
-### 核となる機能
+### Core Features
 
-#### 🔐 認証・ユーザー管理 (Clerk)
+#### 🔐 Authentication & User Management (Clerk)
 
-- **多様な認証方式**: Email/Password、Google OAuth
-- **ユーザー管理**: プロフィール、アカウント設定
-- **セッション管理**: 安全で持続的なログイン
-- **組織管理**: チーム・組織対応（Organization機能）
+- **Multiple authentication methods**: Email/Password, Google OAuth
+- **User management**: Profile, account settings
+- **Session management**: Secure and persistent login
+- **Organization management**: Team and organization support (Organization feature)
 
-#### 💳 決済・サブスクリプション (Stripe)
+#### 💳 Payments & Subscriptions (Stripe)
 
-- **一回購入**: Stripe Checkoutによる安全な決済
-- **サブスクリプション**: 定期課金プラン対応
-- **請求管理**: Clerkの課金ポータル統合
-- **Webhook処理**: リアルタイムでの決済状態更新
+- **One-time purchase**: Secure payments via Stripe Checkout
+- **Subscriptions**: Recurring billing plan support
+- **Billing management**: Clerk billing portal integration
+- **Webhook processing**: Real-time payment status updates
 
-#### 🛡️ セキュリティ・認可
+#### 🛡️ Security & Authorization
 
-- **ルートガード**: 認証が必要なページの保護
-- **機能ベース認可**: プレミアム機能へのアクセス制御
-- **APIセキュリティ**: 認証必須エンドポイントの保護
+- **Route guards**: Protection for pages requiring authentication
+- **Feature-based authorization**: Access control for premium features
+- **API security**: Protection for authentication-required endpoints
 
-## テスト用情報
+## Test Information
 
-### Stripeテストカード番号
+### Stripe Test Card Numbers
 
-- **成功**: 4242 4242 4242 4242
-- **失敗**: 4000 0000 0000 0002
-- **CVV**: 任意の3桁の数字
-- **有効期限**: 未来の日付
+- **Success**: 4242 4242 4242 4242
+- **Failure**: 4000 0000 0000 0002
+- **CVV**: Any 3-digit number
+- **Expiration**: Any future date
 
-## 本番環境構築
+## Production Environment Setup
 
-[本番環境セットアップガイド](docs/production-setup.md)を参照してください。
+Please refer to the [Production Setup Guide](docs/production-setup.md).
 
-## 技術スタック
+## Technology Stack
 
-### フレームワーク・ライブラリ
+### Frameworks & Libraries
 
 - **Frontend**: [Next.js 15](https://nextjs.org/) (with Turbopack)
 - **React**: v19.1.1
-- **TypeScript**: 型安全な開発環境
+- **TypeScript**: Type-safe development environment
 - **UI Components**: [ShadCN/UI](https://ui.shadcn.com/) + [Lucide Icons](https://lucide.dev/)
 - **Styling**: [Tailwind CSS](https://tailwindcss.com/)
 
-### 認証・決済
+### Authentication & Payment
 
-- **認証**: [Clerk](https://clerk.com/docs/quickstarts/nextjs) - 現代的なユーザー管理
-- **決済**: [Stripe](https://docs.stripe.com/) - 安全で柔軟な決済処理
+- **Authentication**: [Clerk](https://clerk.com/docs/quickstarts/nextjs) - Modern user management
+- **Payment**: [Stripe](https://docs.stripe.com/) - Secure and flexible payment processing
 
-### 開発・品質管理
+### Development & Quality Management
 
-- **コード品質**: ESLint + Prettier
+- **Code Quality**: ESLint + Prettier
 - **Git Hooks**: Husky + lint-staged
-- **開発体験**: Turbopack（高速開発サーバー）
+- **Developer Experience**: Turbopack (Fast development server)
 
-## アーキテクチャの特徴
+## Architecture Features
 
 ### 🚀 SaaS Ready
 
-- サブスクリプションモデル対応
-- 機能ベースアクセス制御
-- 組織・チーム管理対応
+- Subscription model support
+- Feature-based access control
+- Organization and team management support
 
-### 🔧 開発者体験
+### 🔧 Developer Experience
 
-- TypeScript完全対応
-- 自動リント・フォーマット
-- Hot Reload（Turbopack）
+- Full TypeScript support
+- Automatic linting and formatting
+- Hot Reload (Turbopack)
 
-### 📈 スケーラビリティ
+### 📈 Scalability
 
-- **Clerk + Stripe**: 認証と決済の統合アーキテクチャ
-- **無料枠**: Clerk 10,000 MAU、豊富な機能
-- **詳細**: [技術スタック比較](docs/techstack.md)
+- **Clerk + Stripe**: Integrated authentication and payment architecture
+- **Free tier**: Clerk 10,000 MAU, rich features
+- **Details**: [Technology Stack Comparison](docs/techstack.md)
 
-## 参考資料
+## References
 
 - Framework: [Next.js](https://nextjs.org/)
 - Auth: [Clerk Documentation](https://clerk.com/docs/quickstarts/nextjs)
 - UI: [ShadCN/UI](https://ui.shadcn.com/)
 - Payment: [Stripe Documentation](https://docs.stripe.com/)
 - Deployment: [Vercel](https://vercel.com/)
-- Blog: [Next.jsとStripeではじめるシンプルなECサイト開発ワークショップ](https://zenn.dev/stripe/books/stripe-nextjs-use-shopping-cart)
+- Blog: [Simple EC Site Development Workshop with Next.js and Stripe](https://zenn.dev/stripe/books/stripe-nextjs-use-shopping-cart)

--- a/docs/clerk-setup.md
+++ b/docs/clerk-setup.md
@@ -1,30 +1,30 @@
-# Clerk 認証セットアップ
+# Clerk Authentication Setup
 
-## 1. Clerkアカウントの作成
+## 1. Create Clerk Account
 
-1. [Clerk](https://clerk.com)でアカウントを作成
-2. 新しいアプリケーションを作成
-   - アプリケーション名を入力
-   - 認証方法を選択（Email、Google、その他）
+1. Create an account at [Clerk](https://clerk.com)
+2. Create a new application
+   - Enter application name
+   - Select authentication methods (Email, Google, others)
 
-## 2. APIキーの取得
+## 2. Obtain API Keys
 
-1. ダッシュボードから「API Keys」を選択
-2. 以下のキーをコピー:
-   - **Publishable Key**: `pk_test_`で始まる文字列
-   - **Secret Key**: `sk_test_`で始まる文字列
+1. Select "API Keys" from the dashboard
+2. Copy the following keys:
+   - **Publishable Key**: String starting with `pk_test_`
+   - **Secret Key**: String starting with `sk_test_`
 
-## 3. Google認証の有効化
+## 3. Enable Google Authentication
 
-1. ダッシュボードで「Social Connections」を選択
-2. 「Google」を有効化
-3. GoogleのOAuth設定:
-   - [Google Cloud Console](https://console.cloud.google.com/)でプロジェクトを作成
-   - OAuth 2.0クライアントIDを作成
-   - 承認済みのリダイレクトURIに以下を追加:
+1. Select "Social Connections" in the dashboard
+2. Enable "Google"
+3. Google OAuth Configuration:
+   - Create a project in [Google Cloud Console](https://console.cloud.google.com/)
+   - Create OAuth 2.0 Client ID
+   - Add the following to Authorized redirect URIs:
      ```
      https://YOUR_CLERK_DOMAIN.accounts.dev/v1/oauth_callback
      ```
-   - クライアントIDとクライアントシークレットをClerkに設定
+   - Configure Client ID and Client Secret in Clerk
 
-詳細は[Clerk公式ガイド](https://clerk.com/docs/authentication/social-connections/google)を参照してください。
+For details, please refer to the [Official Clerk Guide](https://clerk.com/docs/authentication/social-connections/google).

--- a/docs/clerk.md
+++ b/docs/clerk.md
@@ -1,3 +1,3 @@
-# Clerk検討まとめ
+# Clerk Consideration Summary
 
 Refer to https://qiita.com/nakamasato/private/e5ac6ccf01c2b07b6ff1

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -1,32 +1,32 @@
-# 本番環境構築
+# Production Environment Setup
 
-## 1. 環境変数の設定
+## 1. Environment Variables Configuration
 
-本番環境では以下の環境変数を設定する必要があります:
+The following environment variables need to be set in production:
 
-### Stripe本番キー
+### Stripe Production Keys
 
-1. Stripeダッシュボードで本番モードに切り替え
-2. 本番用のAPIキーを取得
-3. 本番用のWebhook署名シークレットを設定
+1. Switch to production mode in Stripe dashboard
+2. Obtain production API keys
+3. Set production webhook signature secret
 
-### Clerk本番キー
+### Clerk Production Keys
 
-1. Clerkダッシュボードで本番用アプリケーションを作成
-2. 本番用のAPIキーを取得
-3. 本番ドメインを設定
+1. Create production application in Clerk dashboard
+2. Obtain production API keys
+3. Configure production domain
 
-### API URL設定
+### API URL Configuration
 
-`NEXT_PUBLIC_API_URL`は本番環境で**必須**の環境変数です：
+`NEXT_PUBLIC_API_URL` is a **required** environment variable in production:
 
-- **目的**: サーバーサイドレンダリング時のAPI呼び出し用URL
-- **設定値**: あなたのVercelドメイン（例：`https://your-project.vercel.app`）
-- **注意**: 設定しないと商品一覧が表示されずエラーになります
+- **Purpose**: URL for API calls during server-side rendering
+- **Value**: Your Vercel domain (e.g., `https://your-project.vercel.app`)
+- **Note**: Without this setting, product listing will not display and cause errors
 
-## 2. Vercelへのデプロイ（推奨）
+## 2. Deploy to Vercel (Recommended)
 
-### 環境変数の設定
+### Environment Variables Setup
 
 ```
 STRIPE_API_KEY=rk_live_your_production_key
@@ -37,35 +37,35 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_your_production_key
 CLERK_SECRET_KEY=sk_live_your_production_key
 ```
 
-### デプロイ手順
+### Deployment Steps
 
-1. GitHubにコードをプッシュ
-2. Vercelでプロジェクトをインポート
-3. 環境変数を設定
-4. デプロイ
+1. Push code to GitHub
+2. Import project in Vercel
+3. Configure environment variables
+4. Deploy
 
-## 3. セキュリティチェックリスト
+## 3. Security Checklist
 
-- [ ] すべてのAPIキーが本番用に変更されている
-- [ ] HTTPS/SSLが有効になっている
-- [ ] Clerkの本番ドメインが正しく設定されている
-- [ ] StripeのWebhook URLが本番URLに設定されている
-- [ ] テストモードのキーが含まれていない
-- [ ] **NEXT_PUBLIC_API_URL**が正しいVercelドメインに設定されている
+- [ ] All API keys are changed to production versions
+- [ ] HTTPS/SSL is enabled
+- [ ] Clerk production domain is correctly configured
+- [ ] Stripe webhook URL is set to production URL
+- [ ] Test mode keys are not included
+- [ ] **NEXT_PUBLIC_API_URL** is set to correct Vercel domain
 
-## 4. Stripe Webhook設定（本番環境）
+## 4. Stripe Webhook Setup (Production)
 
-1. Stripeダッシュボードで「開発者」→「Webhook」を選択
-2. 「エンドポイントを追加」をクリック
-3. エンドポイントURL: `https://your-domain.com/api/webhooks`
-4. 以下のイベントを選択:
+1. Select "Developers" → "Webhooks" in Stripe dashboard
+2. Click "Add endpoint"
+3. Endpoint URL: `https://your-domain.com/api/webhooks`
+4. Select the following events:
    - `checkout.session.completed`
    - `payment_intent.succeeded`
-5. 署名シークレットを環境変数に設定
+5. Set signature secret in environment variables
 
-## 5. 動作確認
+## 5. Functionality Verification
 
-1. 本番環境でユーザー登録・ログインができることを確認
-2. 商品一覧が表示されることを確認
-3. テスト決済が正常に処理されることを確認
-4. Webhook が正常に動作することを確認
+1. Verify user registration and login work in production
+2. Verify product listing displays correctly
+3. Verify test payments are processed correctly
+4. Verify webhooks function properly

--- a/docs/stripe-01-setup.md
+++ b/docs/stripe-01-setup.md
@@ -1,26 +1,26 @@
-# Stripe アカウントセットアップ
+# Stripe Account Setup
 
-## 1. アカウント作成
+## 1. Account Creation
 
-1. [Stripe](https://stripe.com)でアカウントを作成
-2. ダッシュボードにログイン
+1. Create an account at [Stripe](https://stripe.com)
+2. Log in to the dashboard
 
-## 2. APIキーの取得
+## 2. Obtain API Keys
 
-### 公開可能キー
+### Publishable Key
 
-1. 左メニューから「開発者」→「APIキー」を選択
-2. 「公開可能キー」をコピー
+1. Select "Developers" → "API keys" from the left menu
+2. Copy the "Publishable key"
 
-### 制限付きキー（Restricted Key）
+### Restricted Key
 
-1. 「制限付きキーを作成」をクリック
-2. 以下の権限のみを付与:
-   - Products: 読み取り
-   - Prices: 読み取り
-   - Checkout Sessions: 書き込み
-3. 作成したRestricted Keyをコピー
+1. Click "Create restricted key"
+2. Grant only the following permissions:
+   - Products: Read
+   - Prices: Read
+   - Checkout Sessions: Write
+3. Copy the created Restricted Key
 
-## 3. テストモードの確認
+## 3. Verify Test Mode
 
-開発中は必ずテストモードを使用してください。ダッシュボード右上でテストモードがONになっていることを確認してください。
+Always use test mode during development. Ensure test mode is ON in the upper right corner of the dashboard.

--- a/docs/stripe-02-product-and-price.md
+++ b/docs/stripe-02-product-and-price.md
@@ -1,33 +1,33 @@
-# Stripe 商品とPriceの作成
+# Create Stripe Products and Prices
 
-## 1. 商品の作成
+## 1. Create Products
 
-1. Stripeダッシュボードで「商品カタログ」→「商品」を選択
-2. 「商品を追加」をクリック
-3. 以下の情報を入力:
-   - **商品名**: 表示する商品名
-   - **説明**: 商品の詳細説明
-   - **画像**: 商品画像をアップロード
+1. Select "Product catalog" → "Products" in Stripe dashboard
+2. Click "Add product"
+3. Enter the following information:
+   - **Product name**: Display name for the product
+   - **Description**: Detailed product description
+   - **Image**: Upload product image
 
-## 2. 価格（Price）の設定
+## 2. Configure Pricing
 
-1. 商品作成画面で価格情報を設定:
-   - **価格モデル**: 「標準の価格体系」を選択
-   - **価格**: 金額を入力
-   - **通貨**: JPY（日本円）を選択
-   - **請求期間**: 「1回限り」を選択
+1. Set pricing information on the product creation screen:
+   - **Pricing model**: Select "Standard pricing"
+   - **Price**: Enter the amount
+   - **Currency**: Select JPY (Japanese Yen)
+   - **Billing period**: Select "One time"
 
-2. 商品を保存
+2. Save the product
 
-## 3. 商品IDとPrice IDの取得
+## 3. Obtain Product ID and Price ID
 
-保存後、以下のIDをメモしてください:
+After saving, note the following IDs:
 
-- **商品ID**: `prod_`で始まる文字列
-- **Price ID**: `price_`で始まる文字列
+- **Product ID**: String starting with `prod_`
+- **Price ID**: String starting with `price_`
 
-これらのIDは`pages/api/products.ts`で使用します。
+These IDs will be used in `pages/api/products.ts`.
 
-## 4. 複数商品の作成
+## 4. Create Multiple Products
 
-ECサイトに表示する商品の数だけ、上記の手順を繰り返してください。
+Repeat the above steps for as many products as you want to display on your EC site.

--- a/docs/stripe-03-webhook.md
+++ b/docs/stripe-03-webhook.md
@@ -1,8 +1,8 @@
-# Stripe Webhookの設定（開発環境）
+# Stripe Webhook Configuration (Development Environment)
 
-開発環境では、Stripe CLIを使用してWebhookをテストします。
+In development environment, we use Stripe CLI to test webhooks.
 
-## 1. Stripe CLIのインストール
+## 1. Install Stripe CLI
 
 ### macOS
 
@@ -12,37 +12,37 @@ brew install stripe/stripe-cli/stripe
 
 ### Windows
 
-[Stripe CLI ダウンロードページ](https://github.com/stripe/stripe-cli/releases)から最新版をダウンロード
+Download the latest version from [Stripe CLI download page](https://github.com/stripe/stripe-cli/releases)
 
-### その他のOS
+### Other OS
 
-[Stripe CLI公式ドキュメント](https://stripe.com/docs/stripe-cli)を参照
+Refer to [Stripe CLI official documentation](https://stripe.com/docs/stripe-cli)
 
-## 2. Stripe CLIへのログイン
+## 2. Login to Stripe CLI
 
 ```bash
 stripe login
 ```
 
-ブラウザが開くので、Stripeアカウントでログインを承認してください。
+A browser will open. Please authorize login with your Stripe account.
 
-## 3. Webhookイベントの転送
+## 3. Forward Webhook Events
 
-開発サーバーが起動している状態で、以下のコマンドを実行:
+With the development server running, execute the following command:
 
 ```bash
 stripe listen --forward-to http://localhost:3000/api/webhooks
 ```
 
-## 4. 署名シークレットの取得
+## 4. Obtain Signature Secret
 
-コマンド実行後に表示される署名シークレット（`whsec_`で始まる文字列）を`.env.local`ファイルに設定してください。
+Set the signature secret (string starting with `whsec_`) displayed after running the command in your `.env.local` file.
 
-## 5. 動作確認
+## 5. Verify Functionality
 
-決済を行うと、ターミナルにWebhookイベントのログが表示されます。これで決済完了の処理が正しく動作していることを確認できます。
+When you make a payment, webhook event logs will be displayed in the terminal. This confirms that payment completion processing is working correctly.
 
-## 注意事項
+## Notes
 
-- Stripe CLIは開発サーバーが起動している間、実行したままにしてください
-- 開発を再開するたびに`stripe listen`コマンドを実行する必要があります
+- Keep Stripe CLI running while the development server is active
+- You need to run the `stripe listen` command each time you resume development

--- a/docs/techstack.md
+++ b/docs/techstack.md
@@ -1,6 +1,6 @@
 # Tech Stack
 
-## 技術要素
+## Technical Elements
 
 - **Framework**: [Next.js](https://nextjs.org/)
 - **Auth**:
@@ -12,139 +12,139 @@
   - [Neon](https://neon.tech/): free for 0.5GB, $19/month for Pro
 - **Payment**: [Stripe](https://stripe.com/en-jp)
 
-## 実装パターンと評価
+## Implementation Patterns and Evaluation
 
-### 評価基準
+### Evaluation Criteria
 
-- Stripeで決済する
-- Googleでログインする
-- 将来的にはOrg-Membersの関係も必要
-- なるべくシステムはシンプルにしたい
-- SaaSで従量課金系は最初は避けたい、ある程度スケールしたら仕方ない
-- ベンダーロックインに関するリスク（移行工数）
-- データクエリの柔軟性（検索・分析機能）
-- 大規模データでのパフォーマンス（1000+ ユーザー時）
+- Payment processing with Stripe
+- Google login integration
+- Future need for Org-Member relationships
+- Keep the system as simple as possible
+- Avoid usage-based pricing initially, consider it after scaling
+- Risk of vendor lock-in (migration costs)
+- Data query flexibility (search/analytics features)
+- Performance with large datasets (1000+ users)
 
-### 1. 推奨: Clerk + Stripe (DBなし)
+### 1. Recommended: Clerk + Stripe (No DB)
 
-**要件適合度: ⭐⭐⭐⭐⭐ 高**
+**Requirement Fit: ⭐⭐⭐⭐⭐ High**
 
-| 項目               | 評価 | 詳細                                             |
-| ------------------ | ---- | ------------------------------------------------ |
-| Stripe決済         | ◎    | ネイティブ統合                                   |
-| Googleログイン     | ◎    | 標準サポート                                     |
-| Org-Members        | ◎    | Clerk Organizations機能で完全対応                |
-| シンプルさ         | ◎    | 最もシンプル（2サービスのみ）                    |
-| 初期コスト         | ○    | Clerk無料枠10,000 MAU                            |
-| ベンダーロックイン | △    | Clerk依存度高、移行時は認証とOrg機能の再実装必要 |
+| Item           | Rating | Details                                                                                 |
+| -------------- | ------ | --------------------------------------------------------------------------------------- |
+| Stripe Payment | ◎      | Native integration                                                                      |
+| Google Login   | ◎      | Standard support                                                                        |
+| Org-Members    | ◎      | Full support with Clerk Organizations feature                                           |
+| Simplicity     | ◎      | Most simple (only 2 services)                                                           |
+| Initial Cost   | ○      | Clerk free tier 10,000 MAU                                                              |
+| Vendor Lock-in | △      | High Clerk dependency, requires auth and Org feature re-implementation during migration |
 
-**利点**:
+**Benefits**:
 
-- Organization機能が組み込み済みで、実装工数を大幅削減
-- 初期段階ではDBなしでも十分（ユーザー、組織、決済情報は全てClerk/Stripeが管理）
-- 商品・顧客・注文は全てStripe側で管理
-- 管理コスト最小: DBインフラ不要
-- **認証オプションの動的管理**: ダッシュボードから認証方法（メール/パスワード、OAuth等）を追加・削除でき、コード変更不要（Supabase Authでは新しい認証方法の追加時に実装が必要）
+- Organization features built-in, significantly reducing implementation costs
+- Initially sufficient without DB (user, organization, payment information all managed by Clerk/Stripe)
+- Products, customers, orders all managed by Stripe
+- Minimal management cost: No DB infrastructure needed
+- **Dynamic authentication option management**: Add/remove authentication methods (email/password, OAuth, etc.) from dashboard without code changes (Supabase Auth requires implementation for new authentication methods)
 
-**制約**:
+**Constraints**:
 
-- カスタムデータ（ユーザー設定、アクティビティログ等）の保存が困難
-- Stripe/Clerkのデータモデルに依存
-- 複雑なクエリやレポート作成が困難
+- Difficult to store custom data (user settings, activity logs, etc.)
+- Dependent on Stripe/Clerk data models
+- Difficult to create complex queries or reports
 
-**参考記事**:
+**Reference Articles**:
 
 - [Per-user licensing with Stripe and Clerk Organizations](https://clerk.com/blog/per-user-licensing-with-stripe-and-clerk-organizations)
 
 ### 2. Clerk + Supabase DB
 
-**要件適合度: ⭐⭐⭐ 中**
+**Requirement Fit: ⭐⭐⭐ Medium**
 
-| 項目               | 評価 | 詳細                                     |
-| ------------------ | ---- | ---------------------------------------- |
-| Stripe決済         | ◎    | 問題なし                                 |
-| Googleログイン     | ◎    | 標準サポート                             |
-| Org-Members        | ◎    | Clerk Organizations + Supabaseで拡張可能 |
-| シンプルさ         | △    | 3サービス、Webhook連携必要               |
-| 初期コスト         | △    | 2サービス分の料金                        |
-| ベンダーロックイン | △    | Clerk移行時の工数は同じ、DB部分は独立    |
+| Item           | Rating | Details                                                 |
+| -------------- | ------ | ------------------------------------------------------- |
+| Stripe Payment | ◎      | No issues                                               |
+| Google Login   | ◎      | Standard support                                        |
+| Org-Members    | ◎      | Extensible with Clerk Organizations + Supabase          |
+| Simplicity     | △      | 3 services, webhook integration needed                  |
+| Initial Cost   | △      | Cost for 2 services                                     |
+| Vendor Lock-in | △      | Same migration effort for Clerk, DB part is independent |
 
-**利点**:
+**Benefits**:
 
-- カスタムデータの永続化が可能
-- 高機能認証: 多要素認証、デバイス管理、分析
-- 優れたUX: 洗練されたUI/UXコンポーネント
-- エンタープライズ対応: SAML、SCIM等の企業向け機能
+- Custom data persistence possible
+- Advanced authentication: Multi-factor authentication, device management, analytics
+- Excellent UX: Polished UI/UX components
+- Enterprise support: SAML, SCIM, and other enterprise features
 
-**欠点**:
+**Drawbacks**:
 
-- Webhook設定、ID管理が複雑
-- 2つのサービス料金
-- 認証とDBが別サービスによるレイテンシ
-- 連携コードの実装・メンテナンス工数
+- Complex webhook setup and ID management
+- Cost for two services
+- Latency due to separate authentication and DB services
+- Implementation and maintenance effort for integration code
 
-**参考記事**:
+**Reference Articles**:
 
 - [Build a task manager with Next.js, Supabase, and Clerk](https://clerk.com/blog/nextjs-supabase-clerk)
 - [Clerk's Connect with Supabase](https://supabase.com/docs/guides/auth/third-party/clerk)
 
 ### 3. Clerk + Neon DB
 
-**要件適合度: ⭐⭐⭐ 中**
+**Requirement Fit: ⭐⭐⭐ Medium**
 
-| 項目               | 評価 | 詳細                                  |
-| ------------------ | ---- | ------------------------------------- |
-| Stripe決済         | ◎    | 問題なし                              |
-| Googleログイン     | ◎    | 標準サポート                          |
-| Org-Members        | ◎    | Clerk Organizations + Neonで拡張可能  |
-| シンプルさ         | △    | 3サービス、Webhook連携必要            |
-| 初期コスト         | △    | 2サービス分の料金                     |
-| ベンダーロックイン | △    | Clerk移行時の工数は同じ、DB部分は独立 |
+| Item           | Rating | Details                                                 |
+| -------------- | ------ | ------------------------------------------------------- |
+| Stripe Payment | ◎      | No issues                                               |
+| Google Login   | ◎      | Standard support                                        |
+| Org-Members    | ◎      | Extensible with Clerk Organizations + Neon              |
+| Simplicity     | △      | 3 services, webhook integration needed                  |
+| Initial Cost   | △      | Cost for 2 services                                     |
+| Vendor Lock-in | △      | Same migration effort for Clerk, DB part is independent |
 
-**利点**:
+**Benefits**:
 
-- PostgreSQL互換で高パフォーマンス
-- Supabaseより高い可用性・スケーラビリティ
-- カスタムデータの永続化が可能
-- 優れたブランチング機能（開発・本番環境の分離）
+- PostgreSQL compatible with high performance
+- Higher availability and scalability than Supabase
+- Custom data persistence possible
+- Excellent branching features (development/production environment separation)
 
-**欠点**:
+**Drawbacks**:
 
-- Webhook設定、ID管理が複雑
-- 2つのサービス料金
-- Supabaseのような統合認証機能なし
+- Complex webhook setup and ID management
+- Cost for two services
+- No integrated authentication features like Supabase
 
-### 4. Stripe Metadata連携 (DBなし)
+### 4. Stripe Metadata Integration (No DB)
 
-**要件適合度: ⭐⭐⭐⭐ 高（小規模向け）**
+**Requirement Fit: ⭐⭐⭐⭐ High (for small scale)**
 
-| 項目               | 評価 | 詳細                              |
-| ------------------ | ---- | --------------------------------- |
-| Stripe決済         | ◎    | ネイティブ統合                    |
-| Googleログイン     | ◎    | 標準サポート                      |
-| Org-Members        | ◎    | Clerk Organizations機能で完全対応 |
-| シンプルさ         | ◎    | 最もシンプル（DB不要）            |
-| 初期コスト         | ○    | Clerk無料枠10,000 MAU             |
-| ベンダーロックイン | △    | Stripe依存度高、検索性能に制限    |
+| Item           | Rating | Details                                            |
+| -------------- | ------ | -------------------------------------------------- |
+| Stripe Payment | ◎      | Native integration                                 |
+| Google Login   | ◎      | Standard support                                   |
+| Org-Members    | ◎      | Full support with Clerk Organizations feature      |
+| Simplicity     | ◎      | Most simple (no DB needed)                         |
+| Initial Cost   | ○      | Clerk free tier 10,000 MAU                         |
+| Vendor Lock-in | △      | High Stripe dependency, limited search performance |
 
-**利点**:
+**Benefits**:
 
-- データベース設定・管理不要
-- 最小限の実装で連携可能
-- Stripeが自動的にデータ管理
-- 運用コスト最小
+- No database setup or management needed
+- Minimal implementation for integration
+- Stripe automatically manages data
+- Minimal operational cost
 
-**欠点**:
+**Drawbacks**:
 
-- Metadataサイズ制限（50 keys、各500文字）
-- 複雑な検索・クエリが困難
-- 大量ユーザーでの検索パフォーマンス低下
-- Stripe APIに依存したデータアクセス
+- Metadata size limitations (50 keys, 500 characters each)
+- Difficult complex search/queries
+- Search performance degradation with large user base
+- Data access dependent on Stripe API
 
-**実装例**:
+**Implementation Example**:
 
 ```typescript
-// Stripe顧客作成時
+// When creating Stripe customer
 const customer = await stripe.customers.create({
   email: user.primaryEmailAddress?.emailAddress,
   metadata: {
@@ -155,63 +155,63 @@ const customer = await stripe.customers.create({
 
 ### 5. Supabase Auth + Supabase DB
 
-**要件適合度: ⭐⭐ 低**
+**Requirement Fit: ⭐⭐ Low**
 
-| 項目               | 評価 | 詳細                                     |
-| ------------------ | ---- | ---------------------------------------- |
-| Stripe決済         | ○    | 連携は可能だが追加実装必要               |
-| Googleログイン     | ○    | サポートあり                             |
-| Org-Members        | ×    | 自前実装が必要（招待、権限管理等）       |
-| シンプルさ         | ○    | 2サービスだが、認証・Org機能の実装工数大 |
-| 初期コスト         | ◎    | Supabase無料枠500MB                      |
-| ベンダーロックイン | ○    | PostgreSQL互換、移行は比較的容易         |
+| Item           | Rating | Details                                                                   |
+| -------------- | ------ | ------------------------------------------------------------------------- |
+| Stripe Payment | ○      | Integration possible but requires additional implementation               |
+| Google Login   | ○      | Supported                                                                 |
+| Org-Members    | ×      | Requires custom implementation (invitations, permission management, etc.) |
+| Simplicity     | ○      | 2 services but large implementation effort for auth/Org features          |
+| Initial Cost   | ◎      | Supabase free tier 500MB                                                  |
+| Vendor Lock-in | ○      | PostgreSQL compatible, relatively easy migration                          |
 
-**利点**:
+**Benefits**:
 
-- 統合性: 認証・DB・APIが一つのサービスで完結
-- コスト効率: 単一サービスで済む
-- RLS自動連携: auth.uid()で直接データアクセス制御
-- パフォーマンス: 認証とDBが同一インフラ内
+- Integration: Authentication, DB, and API completed within one service
+- Cost efficiency: Single service suffices
+- Automatic RLS integration: Direct data access control with auth.uid()
+- Performance: Authentication and DB within same infrastructure
 
-**欠点**:
+**Drawbacks**:
 
-- Organization機能の実装工数が大きい
-- 認証UIをカスタム実装が必要
-- エンタープライズ機能: 限定的
+- Large implementation effort for Organization features
+- Custom authentication UI implementation needed
+- Enterprise features: Limited
 
-## 移行戦略
+## Migration Strategy
 
-**Clerk + Stripeからの段階的拡張**:
+**Gradual expansion from Clerk + Stripe**:
 
-1. 初期: Clerk + Stripeでスタート（最小構成）
-2. 成長期: カスタムデータが必要になったらSupabaseを追加
-3. 移行時: ユーザーデータはClerk APIでエクスポート可能
+1. Initial: Start with Clerk + Stripe (minimal configuration)
+2. Growth: Add Supabase when custom data becomes necessary
+3. Migration: User data can be exported via Clerk API
 
 ## Pricing
 
-### Clerk Organization制限
+### Clerk Organization Limitations
 
 **Free Plan**:
 
-- 開発環境: 50 MAOs (Monthly Active Organizations) まで、各MAO最大5メンバー
-- 本番環境: 100 MAOs まで、各MAO最大5メンバー
+- Development: Up to 50 MAOs (Monthly Active Organizations), max 5 members per MAO
+- Production: Up to 100 MAOs, max 5 members per MAO
 
-**Pro Plan** ($25 USD/月):
+**Pro Plan** ($25 USD/month):
 
-- 開発環境: 無制限のMAOs、無制限のメンバー数
-- 本番環境: 最初の100 MAOsは無料、101個目以降は$1.00/月、無制限のメンバー数
+- Development: Unlimited MAOs, unlimited members
+- Production: First 100 MAOs free, $1.00/month for 101st and beyond, unlimited members
 
-### Clerkプラン比較
+### Clerk Plan Comparison
 
-| プラン | 料金   | MAU制限        | Organization              | 備考                         |
-| ------ | ------ | -------------- | ------------------------- | ---------------------------- |
-| Free   | $0     | 10,000 MAU     | 100 MAOs (5メンバー/組織) | 個人・小規模プロジェクト向け |
-| Pro    | $25/月 | 10,000 MAU込み | 100 MAOs無料、以降$1/MAO  | B2B SaaS向け                 |
+| Plan | Price  | MAU Limit      | Organization                | Notes                       |
+| ---- | ------ | -------------- | --------------------------- | --------------------------- |
+| Free | $0     | 10,000 MAU     | 100 MAOs (5 members/org)    | For personal/small projects |
+| Pro  | $25/mo | 10,000 MAU inc | 100 MAOs free, $1/MAO after | For B2B SaaS                |
 
-### 料金計算例
+### Pricing Calculation Example
 
-**B2B SaaSの場合** (Pro Plan):
+**B2B SaaS case** (Pro Plan):
 
-- 基本料金: $25/月
-- 200組織の場合: $25 + (200-100) × $1 = $125/月
-- ユーザー数制限なし（10,000 MAUまで基本料金に含まれる）
+- Base fee: $25/month
+- For 200 organizations: $25 + (200-100) × $1 = $125/month
+- No user limit (up to 10,000 MAU included in base fee)


### PR DESCRIPTION
## Why

- To support international contributors and users who prefer English documentation
- To align with the project's technical implementation (Next.js, Clerk, Stripe are primarily English-documented)
- To improve accessibility for a broader developer community

## What

- Translate README.md from Japanese to English including all setup instructions and feature descriptions
- Translate all documentation files in docs/ directory:
  - clerk-setup.md - Clerk authentication setup guide
  - production-setup.md - Production environment configuration
  - stripe-01-setup.md - Stripe account setup instructions
  - stripe-02-product-and-price.md - Product and pricing configuration guide
  - stripe-03-webhook.md - Webhook setup for development environment
  - clerk.md - Clerk consideration summary
  - techstack.md - Comprehensive technology stack comparison and evaluation
- Maintain technical accuracy and proper formatting throughout all translations
- Preserve all code examples, links, and structural elements

## Ref

- Supports internationalization efforts for the project
- Maintains consistency with English-first documentation approach used by integrated services (Clerk, Stripe, Next.js)

🤖 Generated with [Claude Code](https://claude.ai/code)